### PR TITLE
Add password change endpoint

### DIFF
--- a/apps/identity/serializers.py
+++ b/apps/identity/serializers.py
@@ -7,3 +7,26 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ["id", "username", "email", "first_name", "last_name"]
 
+
+class ChangePasswordSerializer(serializers.Serializer):
+    current_password = serializers.CharField(write_only=True)
+    new_password1 = serializers.CharField(write_only=True)
+    new_password2 = serializers.CharField(write_only=True)
+
+    def validate_current_password(self, value):
+        user = self.context["request"].user
+        if not user.check_password(value):
+            raise serializers.ValidationError("Invalid password")
+        return value
+
+    def validate(self, attrs):
+        if attrs.get("new_password1") != attrs.get("new_password2"):
+            raise serializers.ValidationError("Passwords do not match")
+        from django.contrib.auth.password_validation import validate_password
+        user = self.context["request"].user
+        try:
+            validate_password(attrs.get("new_password1"), user=user)
+        except Exception:
+            raise serializers.ValidationError("Invalid password")
+        return attrs
+

--- a/apps/identity/urls.py
+++ b/apps/identity/urls.py
@@ -1,6 +1,12 @@
 from django.urls import path
 
-from .views import LoginView, LogoutView, SessionView, CurrentUserView
+from .views import (
+    LoginView,
+    LogoutView,
+    SessionView,
+    CurrentUserView,
+    ChangePasswordView,
+)
 
 
 app_name = "identity"
@@ -10,5 +16,6 @@ urlpatterns = [
     path("logout", LogoutView.as_view(), name="logout"),
     path("session", SessionView.as_view(), name="session"),
     path("users/me", CurrentUserView.as_view(), name="current_user"),
+    path("users/change-password", ChangePasswordView.as_view(), name="change_password"),
 ]
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -47,5 +47,15 @@ Returns `{"authenticated": true}` when the session is valid. Otherwise a `403` s
 
 Returns the authenticated user's profile.
 
+### Change Password
+`POST /api/users/change-password`
+
+Body parameters:
+- `current_password`
+- `new_password1`
+- `new_password2`
+
+Returns a `204` status code on success.
+
 Other Django projects can authenticate via these endpoints using the standard session authentication mechanism provided by Django REST Framework.
 


### PR DESCRIPTION
## Summary
- implement `ChangePasswordView` for updating passwords
- add `ChangePasswordSerializer`
- expose new API route `/api/users/change-password`
- document change password usage
- test password change success and failure cases

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_683c135364b08330a666f209a0fa5f8c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an endpoint allowing authenticated users to change their password securely.
- **Documentation**
  - Added details about the new password change API endpoint to the developer guide.
- **Tests**
  - Added tests to verify successful password changes and to handle error cases such as mismatched or incorrect passwords.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->